### PR TITLE
fix: let real admins log in without being hijacked by the guest user (#85)

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,6 +42,13 @@ exports.authenticate = async (hookName, {req}) => {
   // If the user is visiting the 'forceauth' endpoint then fall through to the next authenticate
   // plugin (or to the built-in basic auth). This is what forces the real authentication.
   if (req.path === endpoint('forceauth')) return;
+  // Defer to other authn plugins / built-in basic auth when the request
+  // targets the admin pages or carries an explicit Authorization header.
+  // Otherwise a user attempting to log in as a real admin against
+  // /admin/login would be silently logged in as guest (without admin
+  // rights), producing the "Login Failed" redirect loop reported in #85.
+  if (req.path.startsWith('/admin')) return;
+  if (req.headers.authorization) return;
   req.session.user = user;
   return true;
 };


### PR DESCRIPTION
Fixes #85. `exports.authenticate` unconditionally set `req.session.user` to the guest user, so when a user tried to sign in at `/admin/login` with real admin credentials (especially in combination with ep_hash_auth) they were silently logged in as the non-admin guest. The admin page then redirected them back to `/admin/login` with a "Login Failed" toast — the redirect loop the reporter described.

Defer to the next authenticate plugin / the built-in Basic-auth fallback when:
- the request path starts with `/admin` (so the admin route gets real auth), or
- the request already carries an `Authorization` header (so an explicit login attempt isn't overridden).

Other pad traffic still falls through to the guest user as before.