### PR TITLE
docs: use a human-readable README title

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![Publish Status](https://github.com/ether/ep_guest/workflows/Node.js%20Package/badge.svg) [![Backend Tests Status](https://github.com/ether/ep_guest/actions/workflows/test-and-release.yml/badge.svg)](https://github.com/ether/ep_guest/actions/workflows/test-and-release.yml)
 
-# ep\_guest
+# Guest Access for Etherpad
 
 ![Screenshot](docs/img/screenshot.png)
 


### PR DESCRIPTION
Replace the placeholder `ep_guest` heading in README.md with "Guest Access for Etherpad" so browsers of the plugin list on GitHub / npm can see what the plugin does at a glance.